### PR TITLE
Use importlib.resources for accessing files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
     - name: Test
       run: |
         python test.py

--- a/iso639/datafile.py
+++ b/iso639/datafile.py
@@ -1,7 +1,13 @@
 import json
 import pickle
+try:
+    from importlib.resources import files
+    from importlib.abc import Traversable
+except ImportError:
+    # Compatibility for Python <3.9
+    from importlib_resources import files
+    from importlib_resources.abc import Traversable
 
-from pkg_resources import resource_filename
 
 FILENAMES = {
     "pt3": "data/iso-639-3.tab",
@@ -18,16 +24,16 @@ FILENAMES = {
 }
 
 
-def get_file(file_alias: str) -> str:
+def get_file(file_alias: str) -> Traversable:
     """Get the path of a local data file"""
-    return resource_filename(__package__, FILENAMES[file_alias])
+    return files(__package__).joinpath(FILENAMES[file_alias])
 
 
 def load_mapping(file_alias: str) -> dict:
     """Load an ISO 639 mapping JSON file"""
     file_path = get_file(file_alias)
     try:
-        with open(file_path, encoding="utf-8") as f:
+        with file_path.open(encoding="utf-8") as f:
             return json.load(f)
     except FileNotFoundError:
         return {}
@@ -37,7 +43,7 @@ def load_langs() -> list:
     """Load the pickled list of ISO 639 Langs"""
     file_path = get_file("list_langs")
     try:
-        with open(file_path, "rb") as f:
+        with file_path.open("rb") as f:
             return pickle.load(f)
     except FileNotFoundError:
         return []

--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,7 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     package_data={"iso639": ["data/*.json", "data/*.pkl"]},
+    install_requires=[
+        "importlib-resources>=6.1;python_version<'3.9'",
+    ]
 )


### PR DESCRIPTION
Use `importlib.resources.files` instead of `resource_filename` from `setuptools` for accessing resource files, to assure compatibility with Python 3.12. In case of Python 3.8, the backport package `importlib_resources` is used. Closes #16 