### PR TITLE
Added is_valid_language_code to check code validity without raising an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,27 +85,15 @@ You can use the `asdict` method to return ISO 639 values as a Python dictionary
 {'name': 'French', 'pt1': 'fr', 'pt2b': 'fre', 'pt2t': 'fra', 'pt3': 'fra', 'pt5': ''}
 ```
 
-### In Data Structures
+### Other Language Names
 
-Lists of `Lang` instances are sortable by name. 
+In addition to their reference name, some language identifiers may be associated with other names. You can list them using the `other_names` method.
 ```python
->>> [lg.name for lg in sorted([Lang("deu"), Lang("rus"), Lang("eng")])]
-['English', 'German', 'Russian']
-```
-As `Lang` is hashable, `Lang` instances can be added to a set or used as dictionary keys.
-```python
->>> {Lang("de"): "foo", Lang("fr"):  "bar"}
-{Lang(name='German', pt1='de', pt2b='ger', pt2t='deu', pt3='deu', pt5=''): 'foo', Lang(name='French', pt1='fr', pt2b='fre', pt2t='fra', pt3='fra', pt5=''): 'bar'}
-```
-
-### Iterator
-
-`iter_langs()` iterates through all possible `Lang` instances, ordered alphabetically by name.
-
-```python
->>> from iso639 import iter_langs
->>> [lg.name for lg in iter_langs()]
-["'Are'are", "'Auhelawa", "A'ou", ... , 'ǂHua', 'ǂUngkue', 'ǃXóõ']
+>>> lg = Lang("ast")
+>>> lg.name
+'Asturian'
+>>> lg.other_names()
+['Asturleonese', 'Bable', 'Leonese']
 ```
 
 ### Language Types
@@ -141,15 +129,27 @@ Conversely, you can also list all the individual languages that share a common m
 Lang(name='Dari', pt1='', pt2b='', pt2t='', pt3='prs', pt5='')]
 ```
 
-### Other Language Names
+### In Data Structures
 
-In addition to their reference name, some language identifiers may be associated with other names. You can list them using the `other_names` method.
+Lists of `Lang` instances are sortable by name. 
 ```python
->>> lg = Lang("ast")
->>> lg.name
-'Asturian'
->>> lg.other_names()
-['Asturleonese', 'Bable', 'Leonese']
+>>> [lg.name for lg in sorted([Lang("deu"), Lang("rus"), Lang("eng")])]
+['English', 'German', 'Russian']
+```
+As `Lang` is hashable, `Lang` instances can be added to a set or used as dictionary keys.
+```python
+>>> {Lang("de"): "foo", Lang("fr"):  "bar"}
+{Lang(name='German', pt1='de', pt2b='ger', pt2t='deu', pt3='deu', pt5=''): 'foo', Lang(name='French', pt1='fr', pt2b='fre', pt2t='fra', pt3='fra', pt5=''): 'bar'}
+```
+
+### Iterator
+
+`iter_langs` iterates through all possible `Lang` instances, ordered alphabetically by name.
+
+```python
+>>> from iso639 import iter_langs
+>>> [lg.name for lg in iter_langs()]
+["'Are'are", "'Auhelawa", "A'ou", ... , 'ǂHua', 'ǂUngkue', 'ǃXóõ']
 ```
 
 ### Exceptions
@@ -177,36 +177,31 @@ When a deprecated language value is passed to `Lang`, a `DeprecatedLanguageValue
 'Gascon replaced by Occitan (post 1500).'
 ```
 
-## Language Code Validation
+Note that you can use the `is_language` language checker if you don't want to handle exceptions.
 
-The `iso639` library provides a function to check if a language code is valid according to ISO 639 standards.
+### Checker
 
-### `is_language(code, identifiers=None)`
-
-Checks if a given language code is valid.
-
-**Parameters**:
-
-- `code` (str): The language code to validate.
-- `identifiers` (tuple, optional): A tuple of ISO 639 identifier types to validate against (e.g., `'pt2b'`, `'pt2t'`).
-
-**Returns**:
-
-- `bool`: `True` if the code is valid, `False` otherwise.
-
-**Example**:
+The `is_language` function checks if a language value is valid according to ISO 639.
 
 ```python
-from iso639 import is_language
+>>> from iso639 import is_language
+>>> is_language("fr")
+True
+>>> is_language("French")
+True
+```
 
-print(is_language('en'))  # Output: True
-print(is_language('xyz'))  # Output: False
-print(is_language('fre', ('pt2b', 'pt2t')))  # Output: True
+You can restrict the check to certain identifiers or names by passing an additional argument.
+```python
+>>> is_language("fr", "pt3") # only 639-3
+False
+>>> is_language("fre", ("pt2b", "pt2t")) # only 639-2/B or 639-2/T
+True
 ```
 
 ## Speed
 
-`iso639-lang` loads its mappings into memory to process calls much [faster](https://github.com/LBeaudoux/benchmark-iso639) than libraries that rely on an embedded database.
+`iso639-lang` loads its mappings into memory to process calls much [faster](https://github.com/LBeaudoux/benchmark-iso639) than Python libraries that rely on an embedded database.
 
 
 ## Sources

--- a/README.md
+++ b/README.md
@@ -177,6 +177,29 @@ When a deprecated language value is passed to `Lang`, a `DeprecatedLanguageValue
 'Gascon replaced by Occitan (post 1500).'
 ```
 
+## Language Code Validation
+
+The `iso639` library provides a function to check if a language code is valid according to ISO 639 standards.
+
+### `is_valid_language_code(code)`
+
+Checks if a given language code is valid.
+
+**Parameters**:
+
+- `code` (str): The language code to validate.
+
+**Returns**:
+
+- `bool`: `True` if the code is valid, `False` otherwise.
+
+**Example**:
+
+```python
+from iso639 import is_valid_language_code
+
+print(is_valid_language_code('en'))  # Output: True
+print(is_valid_language_code('xyz'))  # Output: False
 
 ## Speed
 

--- a/README.md
+++ b/README.md
@@ -181,13 +181,14 @@ When a deprecated language value is passed to `Lang`, a `DeprecatedLanguageValue
 
 The `iso639` library provides a function to check if a language code is valid according to ISO 639 standards.
 
-### `is_valid_language_code(code)`
+### `is_language(code, identifiers=None)`
 
 Checks if a given language code is valid.
 
 **Parameters**:
 
 - `code` (str): The language code to validate.
+- `identifiers` (tuple, optional): A tuple of ISO 639 identifier types to validate against (e.g., `'pt2b'`, `'pt2t'`).
 
 **Returns**:
 
@@ -196,10 +197,12 @@ Checks if a given language code is valid.
 **Example**:
 
 ```python
-from iso639 import is_valid_language_code
+from iso639 import is_language
 
-print(is_valid_language_code('en'))  # Output: True
-print(is_valid_language_code('xyz'))  # Output: False
+print(is_language('en'))  # Output: True
+print(is_language('xyz'))  # Output: False
+print(is_language('fre', ('pt2b', 'pt2t')))  # Output: True
+```
 
 ## Speed
 

--- a/iso639/__init__.py
+++ b/iso639/__init__.py
@@ -1,7 +1,7 @@
-from .iso639 import Lang, iter_langs, is_valid_language_code
+from .iso639 import Lang, iter_langs, is_language
 
 __all__ = [
     "Lang",
     "iter_langs",
-    "is_valid_language_code"
+    "is_language"
 ]

--- a/iso639/__init__.py
+++ b/iso639/__init__.py
@@ -1,6 +1,7 @@
-from .iso639 import Lang, iter_langs
+from .iso639 import Lang, iter_langs, is_valid_language_code
 
 __all__ = [
     "Lang",
     "iter_langs",
+    "is_valid_language_code"
 ]

--- a/iso639/iso639.py
+++ b/iso639/iso639.py
@@ -361,6 +361,7 @@ def iter_langs() -> Iterator[Lang]:
 
     return (Lang(lang_name) for lang_name in sorted_lang_names)
 
+
 @lru_cache
 def _get_language_values(identifiers_or_names: Tuple[str]) -> Set[str]:
     tags = set(identifiers_or_names)

--- a/iso639/iso639.py
+++ b/iso639/iso639.py
@@ -1,5 +1,6 @@
 from operator import itemgetter
-from typing import Dict, Iterator, List, Optional, Union
+from typing import Dict, Iterator, List, Optional, Union, Set
+from functools import lru_cache
 
 from .datafile import load_file
 from .exceptions import DeprecatedLanguageValue, InvalidLanguageValue
@@ -359,3 +360,34 @@ def iter_langs() -> Iterator[Lang]:
     sorted_lang_names = load_file("list_langs")
 
     return (Lang(lang_name) for lang_name in sorted_lang_names)
+
+@lru_cache(maxsize=1)
+def _get_valid_codes() -> Set[str]:
+    """Get a set of all valid language codes.
+
+    Returns
+    -------
+    Set[str]
+        A set of valid language codes.
+    """
+    from iso639 import iter_langs  # Import here to avoid circular import
+
+    codes = set()
+    for lang in iter_langs():
+        codes.update(filter(None, [lang.pt1, lang.pt2b, lang.pt2t, lang.pt3, lang.pt5]))
+    return codes
+
+def is_valid_language_code(code: str) -> bool:
+    """Check if a given language code is valid according to ISO 639 data.
+
+    Parameters
+    ----------
+    code : str
+        The language code to validate.
+
+    Returns
+    -------
+    bool
+        True if the code is valid, False otherwise.
+    """
+    return code in _get_valid_codes()

--- a/tests/test_iso639.py
+++ b/tests/test_iso639.py
@@ -1,6 +1,6 @@
 import pytest
 
-from iso639 import Lang, iter_langs
+from iso639 import Lang, iter_langs, is_valid_language_code
 from iso639.exceptions import InvalidLanguageValue
 
 
@@ -120,3 +120,17 @@ def test_iter_langs():
     assert all(isinstance(lg, Lang) for lg in lgs)
     assert lg1 == lgs[0]
     assert len(set(lgs)) == len(lgs)
+
+def test_valid_codes():
+    assert is_valid_language_code('en')
+    assert is_valid_language_code('fr')
+    assert is_valid_language_code('de')
+
+def test_invalid_codes():
+    assert not is_valid_language_code('xx')
+    assert not is_valid_language_code('xyz')
+    assert not is_valid_language_code('')
+
+def test_none_input():
+    assert not is_valid_language_code(None)
+

--- a/tests/test_iso639.py
+++ b/tests/test_iso639.py
@@ -1,6 +1,6 @@
 import pytest
 
-from iso639 import Lang, iter_langs, is_valid_language_code
+from iso639 import Lang, iter_langs, is_language
 from iso639.exceptions import InvalidLanguageValue
 
 
@@ -121,16 +121,24 @@ def test_iter_langs():
     assert lg1 == lgs[0]
     assert len(set(lgs)) == len(lgs)
 
-def test_valid_codes():
-    assert is_valid_language_code('en')
-    assert is_valid_language_code('fr')
-    assert is_valid_language_code('de')
 
-def test_invalid_codes():
-    assert not is_valid_language_code('xx')
-    assert not is_valid_language_code('xyz')
-    assert not is_valid_language_code('')
+def test_valid_language():
+    assert is_language('en')
+    assert is_language('fr')
+    assert is_language('de')
+    assert is_language('French')
+
+
+def test_invalid_language():
+    assert not is_language('xx')
+    assert not is_language('xyz')
+    assert not is_language('')
+
+def test_valid_language_with_identifier():
+    assert is_language('fre', ('pt2b', 'pt2t'))
+
+def test_invalid_language_with_identifier():
+    assert not is_language('fr', 'pt3')
 
 def test_none_input():
-    assert not is_valid_language_code(None)
-
+    assert not is_language(None)

--- a/tests/test_iso639.py
+++ b/tests/test_iso639.py
@@ -122,23 +122,36 @@ def test_iter_langs():
     assert len(set(lgs)) == len(lgs)
 
 
-def test_valid_language():
-    assert is_language('en')
-    assert is_language('fr')
-    assert is_language('de')
-    assert is_language('French')
+class TestChecker:
 
+    def test_valid_language(self):
+        assert is_language("fr") is True  # 639-1
+        assert is_language("fra") is True  # 639-3 and 639-2/T
+        assert is_language("fre") is True  # 639-2/B
+        assert is_language("ber") is True  # 639-5
+        assert is_language("French") is True  # name
+        assert is_language("Chinese, Mandarin") is True  # other name
 
-def test_invalid_language():
-    assert not is_language('xx')
-    assert not is_language('xyz')
-    assert not is_language('')
+    def test_invalid_language(self):
+        assert is_language("xx") is False
+        assert is_language("xyz") is False
+        assert is_language("") is False
 
-def test_valid_language_with_identifier():
-    assert is_language('fre', ('pt2b', 'pt2t'))
+    def test_valid_language_with_identifier(self):
+        assert is_language("fr", "pt1") is True
+        assert is_language("fre", ("pt2b", "pt2t")) is True
+        assert is_language("fra", ("pt2b", "pt2t")) is True
 
-def test_invalid_language_with_identifier():
-    assert not is_language('fr', 'pt3')
+    def test_invalid_language_with_identifier(self):
+        assert is_language("fr", "pt3") is False
 
-def test_none_input():
-    assert not is_language(None)
+    def test_none_input(self):
+        assert is_language(None) is False
+
+    def test_wrong_indentifiers_or_names_type(self):
+        with pytest.raises(TypeError):
+            is_language("fr", 42)
+
+    def test_wrong_indentifiers_or_names_value(self):
+        with pytest.raises(ValueError):
+            is_language("fr", "foobar")


### PR DESCRIPTION
Added is_valid_language_code to check code validity without raising an exception.

It uses a cached, threadsafe copy of the data from iter_langs. 

Updated tests and README.md as well. 