### PR TITLE
Claim strong typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .
+    - name: Type Checking
+      run: |
+        python -m pip install mypy
+        python -m mypy iso639
     - name: Test
       run: |
         pip install pytest 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,10 @@ Pushing changes to your forked repository should trigger a [workflow](https://gi
 flake8
 black --check .
 isort --check-only .
+mypy iso639
 ```
 
-`iso639-lang` uses `flake8` for linting, `black` for formatting and `isort` for sorting imports. The configuration of these tools is available in the `.flake8` and `pyproject.toml` files.
+`iso639-lang` uses `flake8` for linting, `black` for formatting, `isort` for sorting imports and `mypy` for type checking. The configuration of these tools is available in the `.flake8` and `pyproject.toml` files.
 
 
 ## Submitting Changes

--- a/iso639/datafile.py
+++ b/iso639/datafile.py
@@ -2,10 +2,10 @@ import json
 from typing import Any
 
 try:
-    from importlib.resources import files
+    from importlib.resources import files  # type: ignore[attr-defined, import-not-found]
 except ImportError:
     # Compatibility for Python <3.9
-    from importlib_resources import files
+    from importlib_resources import files  # type: ignore[no-redef, import-not-found]
 
 
 FILENAMES = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,4 @@ line_length = 79
 packages = ["iso639", "iso639.data"]
 
 [tool.setuptools.package-data]
-iso639 = ["data/*.json"]
+iso639 = ["data/*.json", "py.typed"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ lxml>=5.3.0
 pandas>=2.0.3
 requests>=2.32.3
 pytest>=8.3.2
+mypy>=1.13.0


### PR DESCRIPTION
As described in #26 this PR claims explicit typing of the library, allowing for type checkers to examine types in this codebase and enable type checking of other codebases which import this library.

There are no intended changes to library behaviour in this PR. There *is* an [additional job](https://github.com/LBeaudoux/iso639/compare/master...LachJones:iso639:master?expand=1#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR28) added to the workflows file which performs type checking alongside already existing tests.

Typing errors on imports in `datafile.py` have been ignored, as these imports are python version dependant and will fail for the import intended for other versions of python, much in the same way the import itself will fail (due to not being able to find that import).

Closes #26.